### PR TITLE
[Refactor] Add SECRET_ID env variable to avoid hardcoding

### DIFF
--- a/app/authorizer.py
+++ b/app/authorizer.py
@@ -1,7 +1,10 @@
 import datetime
 import json
+import os
 
 import boto3
+
+SECRET_ID = os.environ("SECRET_ID")
 
 CACHED_AUTH_TOKEN = None # Once set, wait at least TOKEN_CACHE_TIME to look up.
 TOKEN_CACHE_TIME = 300 # seconds
@@ -23,7 +26,7 @@ def retrieve_auth_token():
     if not CACHED_AUTH_TOKEN or token_cache_expired:
         client = boto3.client('secretsmanager')
         secret =  client.get_secret_value(
-            SecretId="app/okta-to-aws-sso"
+            SecretId=SECRET_ID
         )
         secret_string = json.loads(secret['SecretString'])
         CACHED_AUTH_TOKEN = secret_string['auth_token_for_okta']

--- a/app/processor.py
+++ b/app/processor.py
@@ -10,6 +10,7 @@ TARGET_TYPE_GROUP = "UserGroup"
 TARGET_TYPE_USER = "User"
 
 AWS_GROUP_PREFIX = os.environ['GROUP_PREFIX']
+SECRET_ID = os.environ("SECRET_ID")
 SCIM_URL = os.environ['SCIM_URL']
 
 PATCH_OPERATION_FOR_OKTA_EVENT = {
@@ -130,7 +131,7 @@ def get_aws_sso_groups(scim_key):
 def retrieve_scim_key():
     client = boto3.client('secretsmanager')
     secret =  client.get_secret_value(
-        SecretId="app/okta-to-aws-sso"
+        SecretId=SECRET_ID
     )
     secret_string = json.loads(secret['SecretString'])
     scim_key = secret_string['aws_sso_scim_key']

--- a/template.yaml
+++ b/template.yaml
@@ -151,6 +151,7 @@ Resources:
         Variables:
           SCIM_URL: !Ref ScimUrl
           GROUP_PREFIX: !Ref GroupPrefix
+          SECRET_ID: !Ref Secrets
       Role: !GetAtt EventProcessorRole.Arn
 
   TokenAuthorizer:

--- a/template.yaml
+++ b/template.yaml
@@ -161,6 +161,9 @@ Resources:
       Handler: authorizer.lambda_handler
       Runtime: python3.8
       Role: !GetAtt TokenAuthorizerRole.Arn
+      Environment:
+        Variables:
+          SECRET_ID: !Ref Secrets
 
 Outputs:
   OktaEventsApi:

--- a/template.yaml
+++ b/template.yaml
@@ -34,8 +34,8 @@ Metadata:
       for automatic provisioning.
     Labels: ['AWS SSO', 'Okta', 'IAM']
     SpdxLicenseId: MIT
-    LicenseUrl: https://github.com/myles2007/okta-aws-sso-scim-groups-connector/blob/master/LICENSE
-    ReadmeUrl: https://github.com/myles2007/okta-aws-sso-scim-groups-connector/blob/master/README.md
+    LicenseUrl: LICENSE
+    ReadmeUrl: README.md
     HomePageUrl: https://github.com/myles2007/okta-aws-sso-scim-groups-connector
     SourceCodeUrl: https://github.com/myles2007/okta-aws-sso-scim-groups-connector
 


### PR DESCRIPTION
While there was previously no secret hardcoded in the code, there was a
hardcoded name reference which could be broken if the secret name were
to be changed.

This updates ensures that the secret name is dynamically provided to AWS
Lambda so that it will always look up the desired secret.