### PR TITLE
Fix SAR metadata: localize LicenseUrl + ReadmeUrl

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -34,8 +34,8 @@ Metadata:
       for automatic provisioning.
     Labels: ['AWS SSO', 'Okta', 'IAM']
     SpdxLicenseId: MIT
-    LicenseUrl: https://github.com/myles2007/okta-aws-sso-scim-groups-connector/blob/master/LICENSE
-    ReadmeUrl: https://github.com/myles2007/okta-aws-sso-scim-groups-connector/blob/master/README.md
+    LicenseUrl: LICENSE
+    ReadmeUrl: README.md
     HomePageUrl: https://github.com/myles2007/okta-aws-sso-scim-groups-connector
     SourceCodeUrl: https://github.com/myles2007/okta-aws-sso-scim-groups-connector
 


### PR DESCRIPTION
The LicenseUrl and ReadmeUrl properties are intended to be local. They
could not be resolved during the deploy process when they pointed to
GitHub.

This commit restores the repository to a deployable state.